### PR TITLE
refactor: remove unnecessary vertical divider from ToolMenu

### DIFF
--- a/src/components/ToolMenu/ToolMenu.tsx
+++ b/src/components/ToolMenu/ToolMenu.tsx
@@ -72,8 +72,6 @@ export const ToolMenu = () => {
           disabled={!canRedo}
         />
 
-        <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
-
         {/* Main Tools */}
         <IconButton
           name="Select"

--- a/src/components/UiElement/UiElement.tsx
+++ b/src/components/UiElement/UiElement.tsx
@@ -14,6 +14,7 @@ export const UiElement = ({ children, sx, style }: Props) => {
         borderRadius: 2,
         boxShadow: 1,
         borderColor: 'grey.400',
+        p: 0,
         ...sx
       }}
       style={style}


### PR DESCRIPTION
Fixed small left gap in toolbar by removing vertical Divider after Undo/Redo in ToolMenu.

![image](https://github.com/user-attachments/assets/412c97dd-6f31-496d-9013-06362894caa5)
